### PR TITLE
Fix git tag extraction from GITHUB_REF env var

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
       run: echo ::set-env name=VERSION::latest
     - name: Set version from tag
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF#refs/tags/})
+      run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF##*/})
     - name: Build Image
       run: make docker
       env:


### PR DESCRIPTION
Something in the GitHub workflows that will fail on the next git tag push, see similar issue here: https://github.com/oetiker/znapzend/pull/483

This change should work for both branch and tag names.