### PR TITLE
Add ClusterTemplate on tenant creation

### DIFF
--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/taion809/haikunator"
@@ -130,8 +131,14 @@ func NewCRDFromAPITenant(apiTenant Tenant) (*synv1alpha1.Tenant, error) {
 		},
 	}
 
-	if apiTenant.GitRepo != nil {
-		tenant.Spec.GitRepoTemplate = newGitRepoTemplate(&apiTenant.GitRepo.GitRepo, string(apiTenant.Id))
+	repoTmpl := newGitRepoTemplate(&apiTenant.GitRepo.GitRepo, string(apiTenant.Id))
+	tenant.Spec.GitRepoTemplate = repoTmpl
+	tenant.Spec.ClusterTemplate = &synv1alpha1.ClusterSpec{
+		GitRepoTemplate: &synv1alpha1.GitRepoTemplate{
+			APISecretRef: repoTmpl.APISecretRef,
+			RepoName:     "{{ .Name }}",
+			Path:         path.Join(repoTmpl.Path, "cluster-catalogs"),
+		},
 	}
 
 	SyncCRDFromAPITenant(apiTenant.TenantProperties, tenant)

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -183,6 +183,25 @@ func TestNewCRDFromAPITenant(t *testing.T) {
 	}
 }
 
+func TestNewCRDFromAPITenant_ClusterTemplate(t *testing.T) {
+	organization := "foorganization"
+	apiTenant := Tenant{
+		TenantId{
+			Id: Id(fmt.Sprintf("t-%s", t.Name())),
+		},
+		TenantProperties{
+			GitRepo: &RevisionedGitRepo{
+				GitRepo: GitRepo{
+					Url: pointer.ToString(fmt.Sprintf("ssh://git@example.com/%s/t-buzz.git", organization)),
+				},
+			},
+		},
+	}
+	tenant, err := NewCRDFromAPITenant(apiTenant)
+	require.NoError(t, err)
+	assert.Equal(t, organization+"/cluster-catalogs", tenant.Spec.ClusterTemplate.GitRepoTemplate.Path)
+}
+
 func TestNewAPITenantFromCRD(t *testing.T) {
 	for name, test := range tenantTests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds the `.spec.clusterTemplate` required to create cluster repos from tenants.

See [SYN-584 (internal)](https://ticket.vshn.net/browse/SYN-584) for context.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
