### PR TITLE
Add support for Kubernetes 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build: generate
 
 .PHONY: test
 test: generate
-	$(GOTEST) -v -cover ./...
+	$(GOTEST) -cover ./...
 
 .PHONY: run
 run: generate

--- a/pkg/service/api_service_test.go
+++ b/pkg/service/api_service_test.go
@@ -128,7 +128,7 @@ var (
 			Name:      "bootstrap-token",
 			Namespace: clusterA.Namespace,
 			Annotations: map[string]string{
-				"kubernetes.io/service-account.name": clusterA.Name,
+				corev1.ServiceAccountNameKey: clusterA.Name,
 			},
 		},
 		Type: corev1.SecretTypeBootstrapToken,
@@ -140,7 +140,7 @@ var (
 			Namespace:         clusterB.Namespace,
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			Annotations: map[string]string{
-				"kubernetes.io/service-account.name": clusterB.Name,
+				corev1.ServiceAccountNameKey: clusterB.Name,
 			},
 		},
 		Type: corev1.SecretTypeServiceAccountToken,
@@ -153,7 +153,7 @@ var (
 			Namespace:         clusterA.Namespace,
 			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			Annotations: map[string]string{
-				"kubernetes.io/service-account.name": clusterA.Name,
+				corev1.ServiceAccountNameKey: clusterA.Name,
 			},
 		},
 		Type: corev1.SecretTypeServiceAccountToken,
@@ -165,7 +165,7 @@ var (
 			Namespace:         clusterA.Namespace,
 			CreationTimestamp: metav1.NewTime(time.Now()),
 			Annotations: map[string]string{
-				"kubernetes.io/service-account.name": clusterA.Name,
+				corev1.ServiceAccountNameKey: clusterA.Name,
 			},
 		},
 		Type: corev1.SecretTypeServiceAccountToken,

--- a/pkg/service/api_service_test.go
+++ b/pkg/service/api_service_test.go
@@ -148,8 +148,9 @@ var (
 
 	clusterASecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterA.Name,
-			Namespace: clusterA.Namespace,
+			Name:              clusterA.Name,
+			Namespace:         clusterA.Namespace,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
 			Annotations: map[string]string{
 				"kubernetes.io/service-account.name": clusterA.Name,
 			},
@@ -157,12 +158,25 @@ var (
 		Type: corev1.SecretTypeServiceAccountToken,
 		Data: map[string][]byte{"token": []byte("sometoken")},
 	}
+	newClusterASecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "new-secret",
+			Namespace:         clusterA.Namespace,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": clusterA.Name,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+		Data: map[string][]byte{"token": []byte("newtoken")},
+	}
 	testObjects = []client.Object{
 		tenantA,
 		tenantB,
 		clusterA,
 		wrongSecret,
 		clusterBSecret,
+		newClusterASecret,
 		clusterASecret,
 		clusterB,
 		&corev1.ServiceAccount{

--- a/pkg/service/api_service_test.go
+++ b/pkg/service/api_service_test.go
@@ -122,6 +122,18 @@ var (
 			},
 		},
 	}
+	// A secret that seems to have the correct annotation and data, but is not of type service account token
+	wrongSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bootstrap-token",
+			Namespace: clusterA.Namespace,
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": clusterA.Name,
+			},
+		},
+		Type: corev1.SecretTypeBootstrapToken,
+		Data: map[string][]byte{"token": []byte("notAtoken")},
+	}
 	clusterBSecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "anotherName", // We do not have guarantees that the secret name matches any fixed naming scheme
@@ -130,6 +142,7 @@ var (
 				"kubernetes.io/service-account.name": clusterB.Name,
 			},
 		},
+		Type: corev1.SecretTypeServiceAccountToken,
 		Data: map[string][]byte{"token": []byte("someothertoken")},
 	}
 
@@ -141,12 +154,14 @@ var (
 				"kubernetes.io/service-account.name": clusterA.Name,
 			},
 		},
+		Type: corev1.SecretTypeServiceAccountToken,
 		Data: map[string][]byte{"token": []byte("sometoken")},
 	}
 	testObjects = []client.Object{
 		tenantA,
 		tenantB,
 		clusterA,
+		wrongSecret,
 		clusterBSecret,
 		clusterASecret,
 		clusterB,

--- a/pkg/service/api_service_test.go
+++ b/pkg/service/api_service_test.go
@@ -122,10 +122,24 @@ var (
 			},
 		},
 	}
+	clusterBSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "anotherName", // We do not have guarantees that the secret name matches any fixed naming scheme
+			Namespace: clusterB.Namespace,
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": clusterB.Name,
+			},
+		},
+		Data: map[string][]byte{"token": []byte("someothertoken")},
+	}
+
 	clusterASecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterA.Name,
 			Namespace: clusterA.Namespace,
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": clusterA.Name,
+			},
 		},
 		Data: map[string][]byte{"token": []byte("sometoken")},
 	}
@@ -133,6 +147,7 @@ var (
 		tenantA,
 		tenantB,
 		clusterA,
+		clusterBSecret,
 		clusterASecret,
 		clusterB,
 		&corev1.ServiceAccount{
@@ -140,10 +155,12 @@ var (
 				Name:      clusterA.Name,
 				Namespace: clusterA.Namespace,
 			},
-			Secrets: []corev1.ObjectReference{{
-				Name:      clusterASecret.Name,
-				Namespace: clusterASecret.Namespace,
-			}},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterB.Name,
+				Namespace: clusterB.Namespace,
+			},
 		},
 	}
 )

--- a/pkg/service/steward.go
+++ b/pkg/service/steward.go
@@ -117,14 +117,14 @@ func findOldestSAToken(secrets []corev1.Secret, saName string) string {
 	token := ""
 	var created *metav1.Time
 
-	for _, secret := range secrets {
+	for i, secret := range secrets {
 		if secret.Type == corev1.SecretTypeServiceAccountToken && // Not strictly necessary but our testing framework can't handle field selectors
 			secret.Annotations[corev1.ServiceAccountNameKey] == saName &&
 			len(secret.Data[corev1.ServiceAccountTokenKey]) > 0 &&
 			!created.Before(&secret.CreationTimestamp) {
 
 			token = string(secret.Data[corev1.ServiceAccountTokenKey])
-			created = &secret.CreationTimestamp
+			created = &secrets[i].CreationTimestamp
 		}
 	}
 	return token

--- a/pkg/service/steward.go
+++ b/pkg/service/steward.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectsyn/lieutenant-api/pkg/api"
@@ -96,25 +95,18 @@ func (s *APIImpl) InstallSteward(c echo.Context, params api.InstallStewardParams
 }
 
 func (s *APIImpl) getServiceAccountToken(ctx *APIContext, saName string) (string, error) {
-	serviceAccount := &corev1.ServiceAccount{}
-	if err := ctx.client.Get(ctx.Request().Context(), types.NamespacedName{Name: saName, Namespace: s.namespace}, serviceAccount); err != nil {
+
+	secrets := &corev1.SecretList{}
+	if err := ctx.client.List(ctx.Request().Context(), secrets, client.InNamespace(s.namespace)); err != nil {
 		return "", err
 	}
 
-	if len(serviceAccount.Secrets) < 1 {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, "No secret found for ServiceAccount: '%s'", saName)
+	for _, secret := range secrets.Items {
+		if secret.Annotations[corev1.ServiceAccountNameKey] == saName && len(secret.Data[corev1.ServiceAccountTokenKey]) > 0 {
+			return string(secret.Data[corev1.ServiceAccountTokenKey]), nil
+		}
 	}
-	secretName := serviceAccount.Secrets[0]
-	secret := &corev1.Secret{}
-	if err := ctx.client.Get(ctx.Request().Context(), types.NamespacedName{Name: secretName.Name, Namespace: serviceAccount.Namespace}, secret); err != nil {
-		return "", err
-	}
-
-	if len(secret.Data["token"]) < 1 {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, "Secret doesn't contain a token: '%s'", secretName.Name)
-	}
-
-	return string(secret.Data["token"]), nil
+	return "", echo.NewHTTPError(http.StatusServiceUnavailable, "Unable to find token for Cluster. This error might be transient, please try again.")
 }
 
 func createRBAC() []runtime.RawExtension {

--- a/pkg/service/steward_test.go
+++ b/pkg/service/steward_test.go
@@ -3,51 +3,148 @@ package service
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectsyn/lieutenant-api/pkg/api"
 )
 
 func TestInstallSteward(t *testing.T) {
-	e, _ := setupTest(t)
 
-	result := testutil.NewRequest().
-		WithHeader("X-Forwarded-Proto", "https").
-		Get("/install/steward.json?token="+clusterA.Status.BootstrapToken.Token).
-		Go(t, e)
-	assert.Equal(t, http.StatusOK, result.Code())
-	manifests := &corev1.List{}
-	err := result.UnmarshalJsonToObject(&manifests)
-	assert.NoError(t, err)
-	assert.Len(t, manifests.Items, 6)
-	decoder := json.NewSerializer(json.DefaultMetaFactory, scheme, scheme, true)
-	foundSecret := false
-	foundDeployment := false
-	for i, item := range manifests.Items {
-		obj, err := runtime.Decode(decoder, item.Raw)
-		assert.NoError(t, err)
-		if i == 0 {
-			_, ok := obj.(*corev1.Namespace)
-			assert.True(t, ok, "First object needs to be a namespace")
-		}
-		if secret, ok := obj.(*corev1.Secret); ok {
-			foundSecret = true
-			assert.Equal(t, secret.StringData["token"], string(clusterASecret.Data["token"]))
-		}
-		if deployment, ok := obj.(*appsv1.Deployment); ok {
-			foundDeployment = true
-			assert.Equal(t, "https://example.com", deployment.Spec.Template.Spec.Containers[0].Env[0].Value)
-			assert.Equal(t, clusterA.Name, deployment.Spec.Template.Spec.Containers[0].Env[1].Value)
-		}
+	tcs := map[string]struct {
+		bootstrapToken string
+		objs           []client.Object
+		saToken        string
+		clusterName    string
+	}{
+		"default": {
+			bootstrapToken: clusterA.Status.BootstrapToken.Token,
+			objs:           testObjects,
+			saToken:        "sometoken",
+			clusterName:    clusterA.Name,
+		},
+		"reordered": {
+			bootstrapToken: clusterA.Status.BootstrapToken.Token,
+			objs: []client.Object{
+				newClusterASecret,
+				clusterA,
+				tenantA,
+				wrongSecret,
+				clusterASA,
+				clusterASecret,
+			},
+			saToken:     "sometoken",
+			clusterName: clusterA.Name,
+		},
+		"older secret": {
+			bootstrapToken: clusterA.Status.BootstrapToken.Token,
+			objs: []client.Object{
+				newClusterASecret,
+				tenantA,
+				clusterASecret,
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-secret",
+						Namespace:         clusterA.Namespace,
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": clusterA.Name,
+						},
+					},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{"token": []byte("someoldertoken")},
+				},
+				clusterA,
+				wrongSecret,
+				clusterASA,
+			},
+			saToken:     "someoldertoken",
+			clusterName: clusterA.Name,
+		},
+		"even older secret": {
+			bootstrapToken: clusterA.Status.BootstrapToken.Token,
+			objs: []client.Object{
+				tenantA,
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-secret",
+						Namespace:         clusterA.Namespace,
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": clusterA.Name,
+						},
+					},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{"token": []byte("someoldertoken")},
+				},
+				clusterA,
+				wrongSecret,
+				clusterASA,
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "arcane-secret",
+						Namespace:         clusterA.Namespace,
+						CreationTimestamp: metav1.NewTime(time.Unix(0, 0)),
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": clusterA.Name,
+						},
+					},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{"token": []byte("mysterytoken")},
+				},
+				newClusterASecret,
+				clusterASecret,
+			},
+			saToken:     "mysterytoken",
+			clusterName: clusterA.Name,
+		},
 	}
-	assert.True(t, foundSecret, "Could not find secret with steward token")
-	assert.True(t, foundDeployment, "Could not find deployment for steward")
+
+	for n, tc := range tcs {
+		t.Run(n, func(t *testing.T) {
+			e, _ := rawSetupTest(t, tc.objs...)
+
+			result := testutil.NewRequest().
+				WithHeader("X-Forwarded-Proto", "https").
+				Get("/install/steward.json?token="+tc.bootstrapToken).
+				Go(t, e)
+			assert.Equal(t, http.StatusOK, result.Code())
+			manifests := &corev1.List{}
+			err := result.UnmarshalJsonToObject(&manifests)
+			assert.NoError(t, err)
+			assert.Len(t, manifests.Items, 6)
+			decoder := json.NewSerializer(json.DefaultMetaFactory, scheme, scheme, true)
+			foundSecret := false
+			foundDeployment := false
+			for i, item := range manifests.Items {
+				obj, err := runtime.Decode(decoder, item.Raw)
+				assert.NoError(t, err)
+				if i == 0 {
+					_, ok := obj.(*corev1.Namespace)
+					assert.True(t, ok, "First object needs to be a namespace")
+				}
+				if secret, ok := obj.(*corev1.Secret); ok {
+					foundSecret = true
+					assert.Equal(t, tc.saToken, secret.StringData["token"])
+				}
+				if deployment, ok := obj.(*appsv1.Deployment); ok {
+					foundDeployment = true
+					assert.Equal(t, "https://example.com", deployment.Spec.Template.Spec.Containers[0].Env[0].Value)
+					assert.Equal(t, tc.clusterName, deployment.Spec.Template.Spec.Containers[0].Env[1].Value)
+				}
+			}
+			assert.True(t, foundSecret, "Could not find secret with steward token")
+			assert.True(t, foundDeployment, "Could not find deployment for steward")
+		})
+	}
 }
 
 func TestInstallStewardNoToken(t *testing.T) {

--- a/pkg/service/steward_test.go
+++ b/pkg/service/steward_test.go
@@ -56,7 +56,7 @@ func TestInstallSteward(t *testing.T) {
 						Namespace:         clusterA.Namespace,
 						CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 						Annotations: map[string]string{
-							"kubernetes.io/service-account.name": clusterA.Name,
+							corev1.ServiceAccountNameKey: clusterA.Name,
 						},
 					},
 					Type: corev1.SecretTypeServiceAccountToken,
@@ -79,7 +79,7 @@ func TestInstallSteward(t *testing.T) {
 						Namespace:         clusterA.Namespace,
 						CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
 						Annotations: map[string]string{
-							"kubernetes.io/service-account.name": clusterA.Name,
+							corev1.ServiceAccountNameKey: clusterA.Name,
 						},
 					},
 					Type: corev1.SecretTypeServiceAccountToken,
@@ -94,7 +94,7 @@ func TestInstallSteward(t *testing.T) {
 						Namespace:         clusterA.Namespace,
 						CreationTimestamp: metav1.NewTime(time.Unix(0, 0)),
 						Annotations: map[string]string{
-							"kubernetes.io/service-account.name": clusterA.Name,
+							corev1.ServiceAccountNameKey: clusterA.Name,
 						},
 					},
 					Type: corev1.SecretTypeServiceAccountToken,


### PR DESCRIPTION
Kubernetes 1.24+ doesn't create service account token secrets by default anymore. Additionally, when creating a token secret explicitly, the secret isn't added to field secrets in the ServiceAccount object.

This PR changes `getServiceAccountToken` to fetch all service-account-token secrets in the namespace and finds the one with the matching annotation. If there are more than one matching secrets it will return the oldest one.

The API does not create the secret, but relies on the Operator to do so.

Closes #185 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
