### PR TITLE
Fix filtering clusters by tenant

### DIFF
--- a/pkg/service/api_service_test.go
+++ b/pkg/service/api_service_test.go
@@ -65,6 +65,9 @@ var (
 				"some":                     "value",
 				"monitoring.syn.tools/sla": "247",
 			},
+			Labels: map[string]string{
+				synv1alpha1.LabelNameTenant: tenantA.Name,
+			},
 		},
 		Spec: synv1alpha1.ClusterSpec{
 			DisplayName: "Sample Cluster A",
@@ -94,6 +97,9 @@ var (
 			Namespace: "default",
 			Annotations: map[string]string{
 				"existing": "annotation",
+			},
+			Labels: map[string]string{
+				synv1alpha1.LabelNameTenant: tenantB.Name,
 			},
 		},
 		Spec: synv1alpha1.ClusterSpec{

--- a/pkg/service/cluster.go
+++ b/pkg/service/cluster.go
@@ -25,11 +25,16 @@ const (
 )
 
 // ListClusters lists all clusters
-func (s *APIImpl) ListClusters(c echo.Context, _ api.ListClustersParams) error {
+func (s *APIImpl) ListClusters(c echo.Context, p api.ListClustersParams) error {
 	ctx := c.(*APIContext)
 
+	filterOptions := []client.ListOption{client.InNamespace(s.namespace)}
+	if p.Tenant != nil && *p.Tenant != "" {
+		filterOptions = append(filterOptions, client.MatchingLabels{synv1alpha1.LabelNameTenant: *p.Tenant})
+	}
+
 	clusterList := &synv1alpha1.ClusterList{}
-	err := ctx.client.List(ctx.Request().Context(), clusterList, client.InNamespace(s.namespace))
+	err := ctx.client.List(ctx.Request().Context(), clusterList, filterOptions...)
 	if err != nil {
 		return err
 	}

--- a/pkg/service/cluster_test.go
+++ b/pkg/service/cluster_test.go
@@ -39,6 +39,21 @@ func TestListCluster(t *testing.T) {
 	assert.Contains(t, *clusters[0].Annotations, "some")
 }
 
+func TestListCluster_FilteredByTenant(t *testing.T) {
+	e, _ := setupTest(t)
+
+	result := testutil.NewRequest().
+		Get("/clusters?tenant="+tenantA.Name).
+		WithHeader(echo.HeaderAuthorization, bearerToken).
+		Go(t, e)
+	require.Equal(t, http.StatusOK, result.Code())
+	clusters := make([]api.Cluster, 0)
+	err := result.UnmarshalJsonToObject(&clusters)
+	assert.NoError(t, err)
+	assert.Len(t, clusters, 1)
+	assert.Equal(t, clusterA.Spec.DisplayName, *clusters[0].DisplayName)
+}
+
 func TestListClusterMissingBearer(t *testing.T) {
 	e, _ := setupTest(t)
 


### PR DESCRIPTION
Fixes #95 

Filters clusters by tenant using the `syn.tools/tenant` label added by the operator on reconcile.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
