### PR TITLE
Add option to sort cluster list by id, tenant, or displayName

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -468,6 +468,14 @@ paths:
             type: string
           description: Filter clusters by tenant id
           example: aezoo6
+        - in: query
+          name: sort_by
+          schema:
+            type: string
+            enum: [id, tenant, displayName]
+            default: id
+          description: Sort list by field
+          example: id
       responses:
         '200':
           description: Cluster listing. Empty array if no tenants available.

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -510,6 +510,22 @@ func NewListClustersRequest(server string, params *ListClustersParams) (*http.Re
 
 	}
 
+	if params.SortBy != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort_by", runtime.ParamLocationQuery, *params.SortBy); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
 	queryURL.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)

--- a/pkg/api/openapi.go
+++ b/pkg/api/openapi.go
@@ -185,7 +185,13 @@ type Default Reason
 type ListClustersParams struct {
 	// Filter clusters by tenant id
 	Tenant *string `json:"tenant,omitempty"`
+
+	// Sort list by field
+	SortBy *ListClustersParamsSortBy `json:"sort_by,omitempty"`
 }
+
+// ListClustersParamsSortBy defines parameters for ListClusters.
+type ListClustersParamsSortBy string
 
 // CreateClusterJSONBody defines parameters for CreateCluster.
 type CreateClusterJSONBody Cluster
@@ -317,6 +323,13 @@ func (w *ServerInterfaceWrapper) ListClusters(ctx echo.Context) error {
 	err = runtime.BindQueryParameter("form", true, false, "tenant", ctx.QueryParams(), &params.Tenant)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tenant: %s", err))
+	}
+
+	// ------------- Optional query parameter "sort_by" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "sort_by", ctx.QueryParams(), &params.SortBy)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter sort_by: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
@@ -630,74 +643,75 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+R8eU8bybb4Vyn17ycl0fWCsSED0tW7BhLwhADBhkwmiUS5+9guqK7qVFUbTMR3f6ql",
-	"N3d7SQJkdN8/o9Bdfc6ps2+e757Pw4gzYEp6u9+9CAscggJh/tqnsVQgesFZ8lg/DUD6gkSKcObtegdE",
-	"KsJ8hUiA+AipCSDfftbwah7RRyKsJl7NYzgEb9fzE6BezRPwLSYCAm9XiRhqnvQnEGKN5P8LGHm73v9r",
-	"ZvQ17VvZ7AXew0PNGwDDTP0occp8tYA25UD+GmkP+msZcSbBsPEARjimSv/T50wBM//EUUSJjzWlzWup",
-	"yf2+JpJzwPq8QVS8bxcFFhdKCEC3RE0QRsJ80zCMc3A0mi5jXBkaZJl7F0wqEfsqFhCgG5ihKaYxoBBH",
-	"SN8DE0bYGGExJEpgMUMhKBxghb2aB3c4jChomCFnRHFB2LghZ6yhOKeyKSn2dr3NTvM1OgfsKzIFr+Zl",
-	"760gtETqWjQUpKxHnAX11ma74z3UPDWLtMD48Bp8pR84XTWcpfR05O1+Xs7FVLm9h9paJ62+rXv6TPAI",
-	"hCIgvYevGX1vsa8qWG0eIzzksUI4MSBkb9dAfS0iH1M604wfkXEikaaVSISJkI0i233K48Db9fCt9Gpe",
-	"QKQSZBg7dDwCJidkpDpG08f2KcT1W5Cq3lrG4F5g/ER2u93vHgnWNNnMqD7rj74uRnNWQDCv5QmDAhgR",
-	"/TDh1Bc2mAA6JFr/Iy613s0QkSiWseFeiBkeQ4CGM+MLumc9hFmAcKz4GBgIrCBwQKScHEBE+ewdzNAt",
-	"oRQNIf99X8EtFtpTFHmBixa1jCl543swMooonp0YV1ThyfRLpN/O+dm83L33MzQFfekw4kJhpnKnHK+1",
-	"JrCxwThjOCR+qpPLiD2wZwtq/FDzRut8O//RmKhziPiqzw7dMf0F5UNM3YNzmBJJrMcscslK3r5FiqM4",
-	"cYCaXRaGsyARG8ajcUFXjOyJRArfgESRAB8CYD4gPgVhgKTQc4aocU0ADdLIkolj2mpsNtpVvCdMKkzp",
-	"xflxheM9P9bUj0D5E+QOat0jI5BKohEXifqlloDHwFQDGeqNtnJGZ1plJShECvryQiLFb4Bpw5BKn51i",
-	"SoIi4ROlIrnbbOKIGLc9lRPWYKCajpymtAQ0dOj6HwPv31/ijY22L8EXoAb6iXkAxsXg4JTRWRJMS9yw",
-	"/v7X5Gth/DPku8SBujBScqIqfV68c28udUFK3yCR+xAoZ2Mt0QJdYUwV8bmIKknLu2GHtsoVV5l82THZ",
-	"Q2i0NIJ1BaAIBOGBi2NxEGlnqz3pmeD6EOrPmPHGcsJjGiDGVaK/IWbGf8+FuJt4CIKBAnkJIlGYYUxo",
-	"cICVvsrmxmarvtGpt7YHrZ3djc5up/O3VzMpL6E6V/DGvmfc0T4PQ6LzjT+CjU5784/NDt4ZBTud153h",
-	"9utW+4/h6+32ht9ujzb/2Ara7c2R/WwgAHRwtnktYGYfp+QY/dhobP/rpi1b+h3PXo15q9HaarQ2vJoX",
-	"4muuydFnQsLMvzf1i4hiNeIi9HY9Slh818RhsN2p1q/DzKsWRbTvVNlaRDE61tLYmAbAXHQsRbcgCYll",
-	"LP3+EYriISW+yRWbyJ41f2iP5VTCLxDjY4UpH88R5fyYQ20ieDnyFg1Rykkdgs2trdYO6na73f32yT3e",
-	"b9G/D3qtk8GbLf2sd3C4g7c+3h7Ht/7d+/NZcPKt1+Gj+P6v2Bd776LD0+nZ5c7ZaWccX39hVU57wqV6",
-	"BzNZffsbxm8Z0mdkYrLa/UgQ2ru8NDZJCQMUcSnJkILhi3kcUdCMkq8KlxoTRfGw4fMQrXW/7ijeP3p3",
-	"Obj+Ft9N1fb++20VHHb6x1FrT7EmO4WjozdbF6f358HoC8sBBz+QuC4neLPOiFTR5ta2QfJm8/L676OT",
-	"yfFfJ/zToKeGIb0Pjrqzk8Eng6/4997e3tv++2/3f8Lljri4v+jcfCTq8BrOO2cf+3hzp3/27c/W6PJm",
-	"oq7bR7c7d9fHl39dfhIXOx/op4/i9PivvejD9ruP18PrwcEgOLjhfPL2fjx88+nf1cKwD0qCiMAnIwJS",
-	"Rz1slCrxKMUELhGPLmUEpxREA3VdicNH6EXM3OEXKATMJCLqhTReKcQsByP7viA7nVNWUR0LWpH+x5Qi",
-	"HfVzaqMpn1fx3WZzTNR/xkRNYiO6JvZD0H5eP+eRrIezpPoeE7VeXLIZ/XyKHTPyTXPCHEMkAKY0WwWy",
-	"oBqoGysepnVJlffQgdMXYC39JbFRVHsz9MWzuQIFpUDYNKFuH+FAIyRTKDxlPGaFBwEZEyXtoy8eup2A",
-	"AKTTJAtSIiwAUX4LwscSaijEd2i7jfwJFtg3BzQ9XGH6qmHUa2WK0mNTYNo7VYTo5BXS5a8WIs6l3UUP",
-	"6md1akVOmEMxJ6e5sJ2AqYrb75M6vJRj4IjkQmUJPyeBvyopP+0d7NuAUqIpB72KrNyXJcJ8SsA0XqrI",
-	"Coj0dYI2u7C2o1UI62AdC1JXEOogCSsTnQKUWoaxilTXYakwC9tHMY476/HMy1gs+HxgEkwDIAQp8RgK",
-	"Br4HPtYZLR+5U3LlpRym6jtkWfQ8eYvy6/Oq3BrPJ9HruZUEFgS5xGS91kxW+K1qhLmLmA5LllivhyXp",
-	"H65EYw/ON3TSz5+0HVLCXaGTri4IYETYU7RDupSi7IYI7nyIFGI4BONluaEE07y7bzx3X4Tl+iKupMmb",
-	"VtcPAe1zETWqYvKa/YiyRj9jZ2LNtkKBnMrmQinXyCNP8vKfT0AsuHWzj4eaJ8GPBVGzvuay1ZU9wAJE",
-	"N1YTU9GZv94mTv/PjwPP9bA1JPs2wzVRKrKtccJGPOm5Y984Bggxod6uefUf09Lwc93/y/7RCeoeei5J",
-	"S3sgycFSuz1fub43thQCU65wosQHJo3KOvh7/QPUru9T4+SP3et5ZP6EcwnYfW1Y7P4tm0MZ1Nt13wBo",
-	"mhSYKCOZYwKx8wIW+TSrQDcaW40NE90jYDgi3q7Xbmw0NrWFYjUxDG/q/4yhovtwqMtvl0+46j5D5hmg",
-	"VmW0I9TWaGOsNzcC2dzYeLTxR5reVAxAcoxIpxHmUDqBqYKcktpMRjV5xfR2P3+teTIOQ6wzszlmo3PO",
-	"jarjsdR+XM6kgtD7qiE0XZYmF7L3mEilDTE5iPAUE4p1bejyZSvPIpv1V/sJ6FphaPe5ZO6EKhAZAu3r",
-	"LfEkKBYscM/5djIX+xZbKRYGY15+DDZv219/UeREQbhuJzk3oMBC4FmVKrijiJoZ4LiB3oSRmiFzXteG",
-	"jDtG5Jje+HllSdXjHFQsmETYYM4LN6clafr+UPMiLis0Y19HUsi10jJ9cHG9d6BjeWXhVSi2rvyfL62u",
-	"bGX1henSSkO85SL4weKqp5A/Af9GJn1op39wR6SSaAgjLsBlDmxsTtjwUENcTUDcEglohAmVFlhyY2mO",
-	"Xjk5XyWlqs5giJLoyt7GhcJ+BH5yJX3iasi5kkrgyHSqr2zhb4ZoRVuzcthPqzmds4FUezyYPZpHS7W6",
-	"QosTNWBwi4pUZNPph5LptZ6FNqeZRnSg82iv84h+fvGYO0WM2QvTJC5QsFVhTMmUhOoyf+ZU7xGM3YpH",
-	"OvnkRm0lO8+Hg+b3dAniwRJLQVUlt+a5LHQT5gKuOZHpxVwoqLpSdqRZsd9R4cY7i/lpCXd8bz+j5A1i",
-	"YgvxIQkCYI8gzCp2Vznsykieun07T4tBzveBipI7BPW0Ytt4Thcw4jFzatBZNrBPSx7p2rQBIgG6xVIb",
-	"sgHyqCF4oSwq4zBW/qRiGBsFeLkR2hOPLs114kwIYgx1Q/m/fkqo+a5GWbz2ZkXp5ToBihvnO7H98Jfn",
-	"b/fR6/bO9qs1AtSzamdsrvEb3JRF/KhOqkodK7U5Vot1mSdBe5lan8Xqt+j0o4nfaW96WYR/IIP6XQr6",
-	"O3O3/xLTWKDd1TlZwP3F5XmPKRB2PdHUVQH34xCYbU6iIZZ2O6R/i8djEOiiXKofaPArlUvBnWpOVEiL",
-	"HJ4vsUvMzBAjLCXolHZJ46J0g0Vtiwlgqib3C9miAdkztrIr3frIAVjv4hHFZE63srYEv6noI5YXXynV",
-	"xfCIMHj0fk/FbSu5VrUZtZiF+R47+rN/elLYqXXVNgMIIECZZzWDpwme6kPJClgcmYpWxEx/a2vknkpL",
-	"ZMHj8cRAzHpL+4X1HBPIR4QFudobhTqnSOpxty/mmgoEaICudAbXKFbRDXPuqrLmTzbOzK4ZemmAyGoo",
-	"5ogt05fgMqcumCL0ynQZRg50AJRMNas0WsNYs1QESq6i3uFVHF2NMJVwVe4G9KyMc8ufy3pvPUYUwRSl",
-	"eCwbFvXY3Luna7HNN99LZvQu3ajKrRsqnu4gunvX8uuEdvXQBpBWxczTqY5h7sIKIVFIxlVWSzyqFSc1",
-	"gaY8sRyjHe5u1qUnt87ZeCq8SAshMfXcoL7SvvuAhVnezG8GlNTpg9aAbLFgpTqNaHz34RgZxXGLGIUe",
-	"bv/N8Zv9ATru9gcv3QigZhbBX6G356fvUbodskAFvz2p+i2diKZMqFDLD/a+se8bf/iIFWJRPgj7PheB",
-	"8XocJbxJFCET+uKu7UdBFKySus1T8mJ/isR4KUeXb6ys1V1cClAqLh5FUAsYWiUTbZhuxrU89p5GwHRQ",
-	"N+bvGhF+khAVRXXqZmZP7XhLJC31ZeXTC1ISN+BYOX4y+cb8MGTVBGrggP8ib1Lvpf1dftTv7ZFxOrNP",
-	"R/TpoDQ3gx6SsRlB+zwMecAF1O00202hSZCNtx5q81iy1QD0sh8P3XCCj1CC/tUq9OkIfBl+Lts+tE0Z",
-	"vNakK/210cpBlz35D5hzqVQhEmVMlstXT7mSmeRPD7nUbx9yzc2lrFjSsZQjNvezAh1zZYR9QC+ThRzT",
-	"GcUh5N7ZzcbkziJm8pVjjR9LxUNdwxuY83s+F+fHmnWJL1802Rokk92niEGJEq+Ya6k8Db861sr9QGCR",
-	"oT+KQacO5Zd54Qz42cdoCd51p2ju/BMP0VJlKDmRXERrfk9+qrvmAG3Rwoo5kNrAj3U5yz9AXm96Nkj2",
-	"9Z55eJbH+3Szs8Xy+8HJ2QKRHYJ6SnltPIPzc4JYNTRzMfH3zsyWiXPlxGyBCO2BR5bi047LyjvAC+cN",
-	"ebH904ZlK3Xy2UdlBbxPNClbqsNrz8kWKPNZrH6DJj+W2CtmZGtnY79HLf8vZYH/HQZYbUXl9K7Y8Siu",
-	"gX/+qm3D/pSyqjd6zH1MUQBToDwKwWCwi9VNW/MvXNzOrfOeCR7EvsmNbNOjuJpd+i38+pB7TMHY7dYv",
-	"AF0nTP0s+AOYLgQbwHQe7NeU+/Pwc1vshYK+uAZcpqv4XW7htfg//an4Mun8F9vs6YfFx4s/zzqEioTg",
-	"RrOuWehAZb3CMhhdW7vOWXre/f3w9eF/AwAA//8Ll0fTJkkAAA==",
+	"H4sIAAAAAAAC/+Q8+VPbSJf/Spd2q5LU5wNjQwaqvtqPIwFPCBBsSDIJtbSlZ7uh1a10twwmxf++1Ycu",
+	"Sz6SAJma/WUqSK33Xr/78nz3fB5GnAFT0tv+7kVY4BAUCPPXHo2lAtENTpPH+mkA0hckUoQzb9vbJ1IR",
+	"5itEAsSHSI0B+fazhlfziD4SYTX2ah7DIXjbnp8A9WqegG8xERB420rEUPOkP4YQayT/LWDobXv/1czo",
+	"a9q3stkNvIeHmtcHhpn6UeKU+WoObcqB/DXSHvTXMuJMgmHjPgxxTJX+p8+ZAmb+iaOIEh9rSpvXUpP7",
+	"fUUkZ4D1eYOoeN8dFFhcKCEA3RI1RhgJ803DMM7B0Wh2GOPK0CDL3DtnUonYV7GAAN3AFE0wjQGFOEL6",
+	"HpgwwkYIiwFRAospCkHhACvs1Ty4w2FEQcMMOSOKC8JGDTllDcU5lU1JsbftrXear9EZYF+RCXg1L3tv",
+	"BaElUteioSBlPeIsqLfW2x3voeapaaQFxgfX4Cv9wOmq4SylJ0Nv+8tiLqbK7T3UVjpp9W3V06eCRyAU",
+	"Aek9XGb0vcW+qmC1eYzwgMcK4cSAkL1dA/W0iHxM6VQzfkhGiUSaViIRJkI2imz3KY8Db9vDt9KreQGR",
+	"SpBB7NDxCJgck6HqGE0f2acQ129BqnprEYO7gfET2e22v3skWNFkM6P6oj+6nI/mtIBgVssTBgUwJPph",
+	"wqmvrD8GdEC0/kdcar2bIiJRLGPDvRAzPIIADabGF+ycdhFmAcKx4iNgILCCwAGRcrwPEeXTdzBFt4RS",
+	"NID89z0Ft1hoT1HkBS5a1CKm5I3vwcgoonh6bFxRhSfTL5F+O+Nn83L33k/RBPSlw4gLhZnKnXK81prA",
+	"RgbjlOGQ+KlOLiJ2354tqPFDzRuu8u3sRyOiziDiyz47cMf0F5QPMHUPzmBCJLEes8glK3n7FimO4sQB",
+	"anZZGM6CRGwYj0YFXTGyJxIpfAMSRQJ8CID5gPgEhAGSQs8ZosY1BtRPI0smjkmrsd5oV/GeMKkwpedn",
+	"RxWO9+xIUz8E5Y+RO6h1jwxBKomGXCTql1oCHgFTDWSoN9rKGZ1qlZWgECnoywuJFL8Bpg1DKn12gikJ",
+	"ioSPlYrkdrOJI2Lc9kSOWYOBajpymtIS0NCh638MvH9/jdfW2r4EX4Dq6yfmARgXg4MTRqdJMC1xw/r7",
+	"X5OvhfH3kO8CB+rCSMmJqvR58c7dmdQFKX2DRO4DoJyNtEQLdIUxVcTnIqokLe+GHdoqV1xl8mXHZA+h",
+	"4cIItiMARSAID1wci4NIO1vtSU8F14dQb8qMN5ZjHtMAMa4S/Q0xM/57JsTdxAMQDBTICxCJwgxiQoN9",
+	"rPRV1tfWW/W1Tr212W9tba91tjudv7yaSXkJ1bmCN/I94472eBgSnW/8Eax12ut/rHfw1jDY6rzuDDZf",
+	"t9p/DF5vttf8dnu4/sdG0G6vD+1nfQGgg7PNawEz+zglx+jHWmPzXzdt2dLvePZqxFuN1kajtebVvBBf",
+	"c02OPhMSZv69rl9EFKshF6G37VHC4rsmDoPNTrV+HWRetSiiPafK1iKK0bGWxsY0AOaiYym6BUlILGPp",
+	"9Q5RFA8o8U2u2ET2rPlDeyynEn6BGB8rTPlohijnxxxqE8HLkbdoiFKO6xCsb2y0ttDOzs7OXvv4Hu+1",
+	"6F/73dZx/82GftbdP9jCGx9vj+Jb/+792TQ4/tbt8GF8/yn2xe676OBkcnqxdXrSGcXXX1mV0x5zqd7B",
+	"VFbf/obxW4b0GZmYrHY/EoT2Li+NTVLCAEVcSjKgYPhiHkcUNKPkq8KlRkRRPGj4PEQr3W9nGO8dvrvo",
+	"X3+L7yZqc+/9pgoOOr2jqLWrWJOdwOHhm43zk/uzYPiV5YCDH0hcl2O8XmdEqmh9Y9MgebN+cf3X4fH4",
+	"6NMx/9zvqkFI74PDnelx/7PBV/x7d3f3be/9t/s/4WJLnN+fd24+EnVwDWed0489vL7VO/32Z2t4cTNW",
+	"1+3D262766OLTxefxfnWB/r5ozg5+rQbfdh89/F6cN3f7wf7N5yP396PBm8+/7taGPZBSRAR+GRIQOqo",
+	"h41SJR6lmMAl4tGljOCUgmigHVfi8CF6ETN3+AUKATOJiHohjVcKMcvByL4vyE7nlFVUx4JWpP8xpUhH",
+	"/ZzaaMpnVXy72RwR9Z8RUePYiK6J/RC0n9fPeSTr4TSpvkdErRaXbEY/m2LHjHzTnDDHEAmAKc1WgSyo",
+	"BtqJFQ/TuqTKe+jA6Quwlv6S2CiqvRn66tlcgYJSIGyaULePcKARkgkUnjIes8KDgIyIkvbRVw/djkEA",
+	"0mmSBSkRFoAovwXhYwk1FOI7tNlG/hgL7JsDmh6uMH3VMOq1NEXpsgkw7Z0qQnTyCunyVwsR59Luogf1",
+	"szq1IifMoZiR00zYTsBUxe33SR1eyjFwRHKhsoSfk8BflpSfdPf3bEAp0ZSDXkVW7ssSYT4lYBovVWQF",
+	"RPo6QZueW9vRKoR1sI4FqSsIdZCEpYlOAUotw1hFquuwVJiF7aMYx531eGZlLOZ83jcJpgEQgpR4BAUD",
+	"3wUf64yWD90pufRSDlP1HbIsepa8efn1WVVujWeT6NXcSgILglxislprJiv8ljXC3EVMhyVLrFfDkvQP",
+	"l6KxB2cbOunnT9oOKeGu0ElXFwQwJOwp2iE7lKLshgjufIgUYjgE42W5oQTTvLtvPHdfhOX6Iq6kyZvW",
+	"jh8C2uMialTF5BX7EWWNfsbOxIpthQI5lc2FUq6RR57k5T+fgFhwq2YfDzVPgh8LoqY9zWWrK7uABYid",
+	"WI1NRWf+eps4/T8/9j3Xw9aQ7NsM11ipyLbGCRvypOeOfeMYIMSEetvm1X9MS8PPdf8veofHaOfAc0la",
+	"2gNJDpba7fnK9b2xpRCYcoUTJT4waVTWwd/t7aN2fY8aJ3/kXs8i88ecS8Dua8Ni92/ZHMig3q77BkDT",
+	"pMBEGckcEYidF7DIJ1kFutbYaKyZ6B4BwxHxtr12Y62xri0Uq7FheFP/ZwQV3YcDXX67fMJV9xkyzwC1",
+	"KqMdobZGG2O9mRHI+trao40/0vSmYgCSY0Q6jTCH0glMFeSU1GYyqskrprf95bLmyTgMsc7MZpiNzjg3",
+	"qo5HUvtxOZUKQu9SQ2i6LE3OZe8RkUobYnIQ4QkmFOva0OXLVp5FNuuv9hLQtcLQ7kvJ3AlVIDIE2tdb",
+	"4klQLFjgnvPNZC72LbZSLAzGvPwYrGTbpUqMC4WovuBgioYEaBGfQV+FS3Kh/ncwLSBLBWg/AxaHLmjW",
+	"MtrygeKy7Hwuf1EniYJw1VZ3boKChcDTKl11Rw2LTEX1JozUFJnzunhl3EkqpxWNn9fmVH/PQMWCSYSt",
+	"cHLal1PjtL54qHkRlxWqu6dDPeR6fZnCusSju6+TjcrKsFANXvk/X/td2dLvK9O1n4Z4y0Xwg9VfVyF/",
+	"DP6NTBrlzkDgjkgl0QCGXIBLbdjInLDxq4a4GoO4JRLQEBMqLbDkxtIcvXJyvkpqaZ1iESXRlb2Ni9W9",
+	"CPzkSvrE1YBzJZXAkWmlX9nOhJnyFZ2BlcNeWm7qpBKk2uXB9NFcbqrVFVqcqAGDW1SkIhufP5RMr/Us",
+	"tDnNNKIDneh7nUcMRPPn8ClizF6YLnaBgo0KY0rGOFQADqZO9R7B2K14pJNPbhZYsvN8vGp+T7c0Hiyx",
+	"FFRV9m2ey0K7YyYjMCcyvZiJVVVXyo40KxZQKtx4Zz4/LeGO7+1nlLxBTGynYECCANgjCLOK3VUOuzLV",
+	"SN2+HfjFIGcbVUXJHYB6WrGtPacLGPKYOTXoLNooSGsy6frIASIBusVSG7IB8qgheK4sKuMwVv64Yloc",
+	"BXixEdoTjy7NVeJMCGIEdUP5v35KqPm2S1m89mZF6eVaFYob5zu2DfuXZ2/30Ov21uarFQLUs2pnbK7x",
+	"G9yURfyoTqpKHSu1OVbzdZknQXuRWp/G6rfo9KOJ32lvelmEfyCD+l0K+jtzt3+IaczR7uqcLOD+/P5B",
+	"lykQdn/S1FUB9+MQmO2eogGWdn2ld4tHIxDovNxL2NfglyqXgjvVHKuQFjk8W2KXmJkhRlhK0Cntgs5K",
+	"6Qbz+ipjwFSN7+eyRQOyZ2xlV7r1oQOw2sUjismMbmV9DH5T0egsb+ZSqovhIWHw6A2pittWcq1qdWs+",
+	"C/NDAPRn7+S4sPTrqm0GEECAMs9qJmNjPNGHkh21ODIVrYiZ/tbWyF2VlsiCx6OxgZg1v/YK+0MmkA8J",
+	"C3K1Nwp1TpHU426hzTUVCNAAXekMrlGsohvm3FVlzZ+sxJllOPTSAJHVUMwRW6YvwGVOnTNF6JXpMgwd",
+	"6AAomWhWabSGsWbrCZRcRr3Dqzi6GmIq4arcDehaGee2Uxc1B7uMKIIpSvFYNsxrArp38+3/V5P82elA",
+	"yYzepStfuX1IxdMlSXfvWn7f0e5G2gDSqhjKOtUxzJ1bISQKybjKaolHteKkJtCUJ5ZjtMPdzbr05NY5",
+	"G0+FF2khJKae2ySotO8eYGG2S/OrCyV1+qA1INt8WKpOQxrffThCRnHcpkih6dt7c/Rmr4+Odnr9l25G",
+	"UTOb6q/Q27OT9yhdX5mjgt+eVP0WjmxTJlSo5Qd739j3jT98xAqxKB+EfZ+LwHg9jhLeJIqQCX1+1/aj",
+	"IAqWSd3mKXmxP0VivJCji1dqVuouLgQoFRePIqg5DK2SiTZMN4RbHHtPImA6qBvzd40IP0mIiqI6cUO9",
+	"p3a8JZIW+rLy6TkpiRtwLJ2PmXxjdhiybETWd8B/kTep99L+Lr+L4O2SUbpUkO4QpJPc3JB8QEZmRu7z",
+	"MOQBF1C343Y3JidBNn8zc7QClmx3Ab3sxQM3nOBDlKB/tQx9OqNfhJ/Ltg9tUwavNOlKfw61dNBlT/4N",
+	"5lwqVYhEGZPt9+VTrmRo+tNDLvXbh1wzcykrlnQs5YjN/e5Bx1wZYR/Qy2RjyHRGcQi5d3b1MrmziJl8",
+	"5Vjjx1LxUNfwBubsItL52ZFmXeLL5022+sl49yliUKLES+ZaKk/Dr461cr9gmGfoj2LQqUP5ZV44A372",
+	"MVqCd9Upmjv/xEO0VBlKTiQX0Zrfk98SrzhAm7dRYw6kNvBjXc7yL6RXm571k4XCZx6e5fE+3exsvvx+",
+	"cHI2R2QHoJ5SXmvP4PycIJYNzVxM/L0zs0XiXDoxmyNCe+CRpfi047LykvLceUNebH+3YdlSnXz2UVkB",
+	"7xNNyhbq8MpzsjnKfBqr36DJjyX2ihnZytnY71HL/09Z4D/DAKutqJzeFTsexT31L5faNuxvPat6o0fc",
+	"xxQFMAHKoxAMBrv53fTKu7P5zfLcvvGp4EHsm9zINj2Ku+OlH+uvDrnLFIzc8v8c0HXC1M+C34fJXLAB",
+	"TGbBXqbcn4WfW7MvFPTFPeUyXcXvcguvxf8rUcWXSee/2GZPPyw+nv951iFUJAQ3mnXNQgcq6xWWweja",
+	"2nXOskVp+/fD5cP/BQAA//9RbZ2ux0kAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/service/api_service_test.go
+++ b/pkg/service/api_service_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -103,7 +102,7 @@ var (
 			},
 		},
 		Spec: synv1alpha1.ClusterSpec{
-			DisplayName: "Sample Cluster B",
+			DisplayName: "B Sample Cluster",
 			TenantRef: corev1.LocalObjectReference{
 				Name: tenantB.Name,
 			},
@@ -220,8 +219,8 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
-func setupTest(t *testing.T, _ ...[]runtime.Object) (*echo.Echo, client.Client) {
-	return rawSetupTest(t, testObjects...)
+func setupTest(t *testing.T, obj ...client.Object) (*echo.Echo, client.Client) {
+	return rawSetupTest(t, append(testObjects, obj...)...)
 }
 
 func rawSetupTest(t *testing.T, obj ...client.Object) (*echo.Echo, client.Client) {


### PR DESCRIPTION
We want to be able to sort the order of clusters for commodore: https://github.com/projectsyn/commodore/issues/596

Instead of doing this in commodore itself we implemented it in the API, which I think is the better approach

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
